### PR TITLE
Fixed bottom copyright info overflowed

### DIFF
--- a/syzoj/templates/layout.html
+++ b/syzoj/templates/layout.html
@@ -115,10 +115,10 @@ $(document).ready(function(){
 
 <footer data-am-widget="footer" class="am-footer am-footer-default">
     <div class="am-footer-miscs ">
-       <p>CopyRight©2015 郑州市第十一中学.<a href="http://www.miibeian.gov.cn/" target="_blank">豫ICP备15011071号</a></p>
+       <p style="width: 100%; ">CopyRight©2015 郑州市第十一中学.<a href="http://www.miibeian.gov.cn/" target="_blank">豫ICP备15011071号</a></p>
     </div>
     <div class="am-footer-miscs ">
-       <p>郑州十一中在线评测系统基于开源系统<a href="https://github.com/Chenyao2333/syzoj" target="_blank">SYZOJ</a>.</p>
+       <p style="width: 100%; ">郑州十一中在线评测系统基于开源系统<a href="https://github.com/Chenyao2333/syzoj" target="_blank">SYZOJ</a>.</p>
     </div>
 </footer>
 </body>


### PR DESCRIPTION
Fixed this:

![syzojoverflow](https://cloud.githubusercontent.com/assets/11341955/18630348/97917822-7e9e-11e6-9259-3916a7236694.png)
